### PR TITLE
Delete parameter 'Firmware' from 'DomainOS', and add it to 'DomainOSType'

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -2045,6 +2045,11 @@ type DomainCPUTuneIOThreadSched struct {
 	Priority  *int   `xml:"priority,attr"`
 }
 
+type DomainCPUTuneEmulatorSched struct {
+	Scheduler string `xml:"scheduler,attr,omitempty"`
+	Priority  *int   `xml:"priority,attr"`
+}
+
 type DomainCPUCacheTune struct {
 	VCPUs   string                      `xml:"vcpus,attr,omitempty"`
 	Cache   []DomainCPUCacheTuneCache   `xml:"cache"`
@@ -2088,6 +2093,7 @@ type DomainCPUTune struct {
 	EmulatorPin    *DomainCPUTuneEmulatorPin    `xml:"emulatorpin"`
 	IOThreadPin    []DomainCPUTuneIOThreadPin   `xml:"iothreadpin"`
 	VCPUSched      []DomainCPUTuneVCPUSched     `xml:"vcpusched"`
+	EmulatorSched  *DomainCPUTuneEmulatorSched  `xml:"emulatorsched"`
 	IOThreadSched  []DomainCPUTuneIOThreadSched `xml:"iothreadsched"`
 	CacheTune      []DomainCPUCacheTune         `xml:"cachetune"`
 	MemoryTune     []DomainCPUMemoryTune        `xml:"memorytune"`


### PR DESCRIPTION

As the title.
I think it would be better If 'DomainOSType' has the parameter 